### PR TITLE
Detect URLs based on hostname

### DIFF
--- a/public/embed.js
+++ b/public/embed.js
@@ -5,7 +5,7 @@
   style.innerHTML = ".webring-anchor{font-size:24px;color:rgba(132,146,166,.8);text-decoration:none;transition:color .5s}.webring-anchor:hover{color:#8492a6;text-decoration:none}.webring-logo{background-image:url(https://assets.hackclub.com/icon-rounded.svg);background-repeat:no-repeat;background-position:top left;background-size:contain;-webkit-flex-shrink:0;-ms-flex-negative:0;flex-shrink:0;display:inline-block;width:36px;height:36px;margin:0 4px;vertical-align:middle}";
   wrapper.appendChild(style);
 
-  var siteHost = document.location.href.toLowerCase();
+  var siteHost = document.location.hostname.toLowerCase();
   var siteIndex = 0;
   var previousIndex = 0;
   var nextIndex = 0;
@@ -22,7 +22,7 @@
     const webring = request.response;
 
     for (var i=0; i<webring.length; i++) {
-      if (siteHost ==  webring[i].url.toLowerCase()) {
+      if (siteHost ==  new URL(webring[i].url).hostname) {
         siteIndex = i;
         break;
       }

--- a/public/members.json
+++ b/public/members.json
@@ -1,7 +1,7 @@
 [
   {
     "member": "Googol",
-    "url": "https://googol88.github.io/"
+    "url": "https://googol.now.sh/"
   },
   {
     "member": "Caleb Denio",

--- a/public/script.js
+++ b/public/script.js
@@ -16,7 +16,7 @@ request.onload = function() {
     row.appendChild(memberCell);
 
     var url = webring[i].url;
-    var urlShort = url.replace(/(^\w+:|^)\/\//, '').split("?")[0];
+    var urlShort = new URL(url).hostname;
     var urlCell = document.createElement("td");
     urlCell.innerHTML = "<a href='"+url+"' target='_blank'>"+urlShort+"</a>";
     row.appendChild(urlCell);


### PR DESCRIPTION
Using matching URL hrefs is not the best way to compare URLs since hash and query parameters will cause the webring to fail. Hostname, however, compares only the domain, subdomain, and TLD portion, for example "example.example.org", which is all the info we need to find the index of the site within the `members.json` list.

The `index.html` page also uses the URL hostname to display the site's location, so that the "/" symbol is no longer at the end of each link.

Finally, my website [googol88.github.io](https://googol88.github.io/) was changed to [googol.now.sh](https://googol.now.sh/).