### PR TITLE
Patched CVE-2022-0235 - node-fetch Unauthorized Actor

### DIFF
--- a/scripts/yarn.lock
+++ b/scripts/yarn.lock
@@ -195,9 +195,9 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.7:
   version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
@@ -275,7 +275,7 @@ puppeteer@^8.0.0:
     devtools-protocol "0.0.854822"
     extract-zip "^2.0.0"
     https-proxy-agent "^5.0.0"
-    node-fetch "^2.6.1"
+    node-fetch "^2.6.7"
     pkg-dir "^4.2.0"
     progress "^2.0.1"
     proxy-from-env "^1.1.0"


### PR DESCRIPTION
node-fetch is vulnerable to Exposure of Sensitive Information to an Unauthorized Actor

upgrade node-fetch to version 2.6.7 :
```
node-fetch@^2.6.7:
  version "2.6.7"
```