### PR TITLE
Use an iframe to embed the webring

### DIFF
--- a/public/embed.html
+++ b/public/embed.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+</head>
+
+<body>
+    <div id="webring-wrapper">
+      <a href="https://webring.hackclub.com/" id="previousBtn" class="webring-anchor" title="Previous">‹</a>
+      <a href="https://webring.hackclub.com/" class="webring-logo" title="Hack Club Webring" alt="Hack Club Webring"></a>
+      <a href="https://webring.hackclub.com/" id="nextBtn" class="webring-anchor" title="Next">›</a>
+      <script src="https://webring.hackclub.com/embed.min.js"></script>
+    </div>
+</body>
+
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<html>
 <html lang="en">
 
 <head>
@@ -50,21 +49,12 @@
         <p class="lead">Insert the following HTML into your website:</p>
         <div class="row">
             <div class="col-sm-4 text-center my-5">
-                <div id="webring-wrapper">
-                    <a  href="#" id="previousBtn" class="webring-anchor" title="Previous">‹</a>
-                    <a  href="#" class="webring-logo" title="Hack Club Webring" alt="Hack Club Webring"></a>
-                    <a  href="#" id="nextBtn" class="webring-anchor" title="Next">›</a>
-                </div>
+                <iframe src="/embed.html" width="90px" height="60px" frameborder="0"></iframe>
                 <p class="small text-muted mt-3">Live preview</p>
             </div>
             <div class="col-sm">
                 <pre class="px-4 rounded-lg"><code>
-&#x3C;div id=&#x22;webring-wrapper&#x22;&#x3E;
-  &#x3C;a href=&#x22;https://webring.hackclub.com/&#x22; id=&#x22;previousBtn&#x22; class=&#x22;webring-anchor&#x22; title=&#x22;Previous&#x22;&#x3E;&#x2039;&#x3C;/a&#x3E;
-  &#x3C;a href=&#x22;https://webring.hackclub.com/&#x22; class=&#x22;webring-logo&#x22; title=&#x22;Hack Club Webring&#x22; alt=&#x22;Hack Club Webring&#x22;&#x3E;&#x3C;/a&#x3E;
-  &#x3C;a href=&#x22;https://webring.hackclub.com/&#x22; id=&#x22;nextBtn&#x22; class=&#x22;webring-anchor&#x22; title=&#x22;Next&#x22;&#x3E;&#x203A;&#x3C;/a&#x3E;
-  &#x3C;script src=&#x22;https://webring.hackclub.com/embed.min.js&#x22;&#x3E;&#x3C;/script&#x3E;
-&#x3C;/div&#x3E;
+&#x3C;iframe src="https://webring.hackclub.com/embed.html" width="90px" height="60px" frameborder="0"&#x3E;&#x3C;iframe&#x3E;
           </code></pre>
             </div>
         </div>


### PR DESCRIPTION
I think an iframe is better then what is currently being done because you aren't
embedding a javascript script on your website.

Also because the CSS of the outside page would not affect the CSS inside of the iframe,
which may be good or bad, depending on how you see it.

Now I think that before being deployed it should be tested to see if it actually works.

I can also rewrite my commit to instead show both ways to embed the webring if this is preferred.

Edit: what could be even better would be if the server rendered the /embed this way you don't have to run javascript for the webring, like what johnvertisements are doing.
Edit 2: though i would need guidance for that