### PR TITLE
fix: webring join code being interpreted as html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,7 @@
             </div>
             <div class="col-sm">
                 <pre class="px-4 rounded-lg"><code>
-<iframe style="border:none;" src="https://webring.hackclub.com/embed.html" width="90px" height="60px"></iframe>
+&#x3C;iframe style="border:none;" src="https://webring.hackclub.com/embed.html" width="90px" height="60px"&#x3E;&#x3C;/iframe&#x3E;
           </code></pre>
             </div>
         </div>


### PR DESCRIPTION
Instead use HTML escape codes to prevent it
being interpreted as actual HTML.

My original fix was overwritten by another commit. It's fine tho.